### PR TITLE
[Refactor] Use `math/big.Rat` instead of custom implementations

### DIFF
--- a/expressions.go
+++ b/expressions.go
@@ -81,7 +81,7 @@ func (b *binaryOperation) Eval() (*fraction, error) {
 	case "/":
 		return lf.Div(lr)
 	case "^":
-		return lf.Pow(lr)
+		return lf.Exp(lr)
 	default:
 		return nil, errors.Join(ErrUnknownOperation, errors.New("operation "+string(b.Operator)+" is not supported"))
 	}

--- a/fraction.go
+++ b/fraction.go
@@ -17,6 +17,7 @@ var (
 	nullBigInt   = big.NewInt(0)
 	oneFraction  = intToFraction(1)
 	nullFraction = intToFraction(0)
+	pi           *fraction
 
 	// ErrFractionNotInt is thrown when a non-integer fraction is converted into an int
 	ErrFractionNotInt = errors.New("fraction is not an int")
@@ -25,6 +26,14 @@ var (
 	// ErrUnsupportedOperation is thrown when an unsupported operation is performed
 	ErrUnsupportedOperation = errors.New("unsupported operation")
 )
+
+func init() {
+	var err error
+	pi, err = floatToFraction(math.Pi)
+	if err != nil {
+		panic(err)
+	}
+}
 
 func newFraction(a, b int64) *fraction {
 	return &fraction{big.NewRat(a, b)}

--- a/fraction.go
+++ b/fraction.go
@@ -90,7 +90,7 @@ func (f fraction) SmallerOrEqualThan(b *fraction) bool {
 }
 
 func (f fraction) SmallerThan(b *fraction) bool {
-	return f.SmallerOrEqualThan(b) && f != *b
+	return f.SmallerOrEqualThan(b) && !f.Is(b)
 }
 
 func (f fraction) GreaterOrEqualThan(b *fraction) bool {

--- a/fraction.go
+++ b/fraction.go
@@ -62,7 +62,11 @@ func (f *fraction) Approx(precision int) string {
 		n, _ := f.Int()
 		return fmt.Sprintf("%d", n)
 	}
-	return f.Rat.FloatString(precision)
+	s := strings.TrimSuffix(f.Rat.FloatString(precision), "0")
+	for strings.HasSuffix(s, "0") {
+		s = strings.TrimSuffix(s, "0")
+	}
+	return s
 }
 
 func (f *fraction) SmallerOrEqualThan(b *fraction) bool {

--- a/fraction.go
+++ b/fraction.go
@@ -14,9 +14,8 @@ type fraction struct {
 }
 
 var (
-	nullFraction = newFraction(0, 1)
-	oneFraction  = newFraction(1, 1)
-	nullBigInt   = big.NewInt(0)
+	// nullFraction MUST NOT BE MODIFIED
+	nullBigInt = big.NewInt(0)
 
 	// ErrFractionNotInt is thrown when a non-integer fraction is converted into an int
 	ErrFractionNotInt = errors.New("fraction is not an int")
@@ -28,6 +27,14 @@ var (
 
 func newFraction(a, b int64) *fraction {
 	return &fraction{big.NewRat(a, b)}
+}
+
+func oneFraction() *fraction {
+	return intToFraction(1)
+}
+
+func nullFraction() *fraction {
+	return intToFraction(0)
 }
 
 // intToFraction converts an int64 into a fraction
@@ -159,9 +166,9 @@ func (f *fraction) Exp(a *fraction) (*fraction, error) {
 		fl, _ := f.Float()
 		if fl == 0 {
 			if n.Cmp(nullBigInt) == 0 {
-				return oneFraction, nil
+				return oneFraction(), nil
 			}
-			return nullFraction, nil
+			return nullFraction(), nil
 		}
 		f.Num().Exp(f.Num(), n, nil)
 		f.Denom().Exp(f.Denom(), n, nil)

--- a/fraction.go
+++ b/fraction.go
@@ -17,7 +17,6 @@ var (
 	nullFraction = newFraction(0, 1)
 	oneFraction  = newFraction(1, 1)
 	nullBigInt   = big.NewInt(0)
-	oneBigInt    = big.NewInt(1)
 
 	// ErrFractionNotInt is thrown when a non-integer fraction is converted into an int
 	ErrFractionNotInt = errors.New("fraction is not an int")
@@ -50,15 +49,15 @@ func floatToFraction(f float64) (*fraction, error) {
 	return newFraction(i, int64(math.Pow(10, float64(len(sp[1]))))), nil
 }
 
-func (f fraction) String() string {
+func (f *fraction) String() string {
 	return f.Rat.RatString()
 }
 
-func (f fraction) Is(a *fraction) bool {
+func (f *fraction) Is(a *fraction) bool {
 	return f.Rat.Num().Cmp(a.Rat.Num()) == 0 && f.Denom().Cmp(a.Denom()) == 0
 }
 
-func (f fraction) Approx(precision int) string {
+func (f *fraction) Approx(precision int) string {
 	if f.IsInt() {
 		n, _ := f.Int()
 		return fmt.Sprintf("%d", n)
@@ -66,81 +65,77 @@ func (f fraction) Approx(precision int) string {
 	return f.Rat.FloatString(precision)
 }
 
-func (f fraction) Copy() *fraction {
-	return &f
-}
-
-func (f fraction) SmallerOrEqualThan(b *fraction) bool {
-	b = b.Copy()
-
+func (f *fraction) SmallerOrEqualThan(b *fraction) bool {
+	x := big.NewInt(0)
+	y := big.NewInt(0)
 	// fractions are always simplified
-	f.Num().Mul(f.Num(), b.Denom())
-	b.Num().Mul(b.Num(), f.Denom())
+	x.Mul(f.Num(), b.Denom())
+	y.Mul(b.Num(), f.Denom())
 
-	return f.Num().Cmp(b.Num()) <= 0
+	return x.Cmp(y) <= 0
 }
 
-func (f fraction) SmallerThan(b *fraction) bool {
+func (f *fraction) SmallerThan(b *fraction) bool {
 	return f.SmallerOrEqualThan(b) && !f.Is(b)
 }
 
-func (f fraction) GreaterOrEqualThan(b *fraction) bool {
+func (f *fraction) GreaterOrEqualThan(b *fraction) bool {
 	return !f.SmallerThan(b)
 }
 
-func (f fraction) GreaterThan(b *fraction) bool {
+func (f *fraction) GreaterThan(b *fraction) bool {
 	return !f.SmallerOrEqualThan(b)
 }
 
 // Add a fraction
-func (f fraction) Add(a *fraction) *fraction {
+func (f *fraction) Add(a *fraction) *fraction {
 	f.Rat.Add(f.Rat, a.Rat)
-	return &f
+	return f
 }
 
-func (f fraction) Neg() *fraction {
+func (f *fraction) Neg() *fraction {
 	f.Num().Mul(f.Num(), big.NewInt(-1))
-	return &f
+	return f
 }
 
 // Sub (subtract) a fraction
-func (f fraction) Sub(a *fraction) *fraction {
+func (f *fraction) Sub(a *fraction) *fraction {
 	return f.Add(a.Neg())
 }
 
 // Mul (multiply) by fraction
-func (f fraction) Mul(a *fraction) *fraction {
+func (f *fraction) Mul(a *fraction) *fraction {
 	f.Rat.Mul(f.Rat, a.Rat)
-	return &f
+	return f
 }
 
 // Inv (invert) the fraction
-func (f fraction) Inv() (*fraction, error) {
+func (f *fraction) Inv() (*fraction, error) {
 	if f.Num().Cmp(nullBigInt) == 0 {
-		return &f, errors.Join(ErrIllegalOperation, errors.New("cannot invert a null fraction"))
+		return f, errors.Join(ErrIllegalOperation, errors.New("cannot invert a null fraction"))
 	}
 	f.Rat.Inv(f.Rat)
-	return &f, nil
+	return f, nil
 }
 
 // Div (divide) by a fraction
-func (f fraction) Div(a *fraction) (*fraction, error) {
+func (f *fraction) Div(a *fraction) (*fraction, error) {
 	invA, err := a.Inv()
 	if err != nil {
-		return &f, errors.Join(err, errors.New("cannot divide by a null fraction"))
+		return f, errors.Join(err, errors.New("cannot divide by a null fraction"))
 	}
 	mul := f.Mul(invA)
 	return mul, nil
 }
 
 // IsInt returns true if the fraction is an int
-func (f fraction) IsInt() bool {
+func (f *fraction) IsInt() bool {
 	return f.Rat.IsInt()
 }
 
 // Int convers the fraction to an int.
 // Returns ErrFractionNotInt if the fraction isn't an int (check before with fraction.IsInt)
-func (f fraction) Int() (*big.Int, error) {
+func (f *fraction) Int() (*big.Int, error) {
 	if !f.IsInt() {
 		return nullBigInt, errors.Join(ErrFractionNotInt, errors.New(f.String()+" is not an int"))
 	}
@@ -149,12 +144,12 @@ func (f fraction) Int() (*big.Int, error) {
 }
 
 // Float converts the fraction to a float
-func (f fraction) Float() (float64, bool) {
+func (f *fraction) Float() (float64, bool) {
 	return f.Rat.Float64()
 }
 
 // Exp the fraction by another
-func (f fraction) Exp(a *fraction) (*fraction, error) {
+func (f *fraction) Exp(a *fraction) (*fraction, error) {
 	if a.IsInt() {
 		n, _ := a.Int()
 		fl, _ := f.Float()
@@ -166,7 +161,7 @@ func (f fraction) Exp(a *fraction) (*fraction, error) {
 		}
 		f.Num().Exp(f.Num(), n, nil)
 		f.Denom().Exp(f.Denom(), n, nil)
-		return &f, nil
+		return f, nil
 	}
 	//afl, _ := a.Float()
 	//nf, err := floatToFraction(math.Pow(float64(f.Num().P), afl))

--- a/fraction.go
+++ b/fraction.go
@@ -17,6 +17,7 @@ var (
 	nullFraction = newFraction(0, 1)
 	oneFraction  = newFraction(1, 1)
 	nullBigInt   = big.NewInt(0)
+	oneBigInt    = big.NewInt(1)
 
 	// ErrFractionNotInt is thrown when a non-integer fraction is converted into an int
 	ErrFractionNotInt = errors.New("fraction is not an int")
@@ -49,24 +50,12 @@ func floatToFraction(f float64) (*fraction, error) {
 	return newFraction(i, int64(math.Pow(10, float64(len(sp[1]))))), nil
 }
 
-func gcd(a, b *big.Int) *big.Int {
-	for b.Cmp(nullBigInt) != 0 {
-		a, b = b, a.Mod(a, b)
-	}
-	return a
-}
-
 func (f fraction) String() string {
-	if f.Denom().Cmp(big.NewInt(1)) != 0 {
-		return f.Rat.String()
-	}
-	return f.Num().String()
+	return f.Rat.RatString()
 }
 
 func (f fraction) Is(a *fraction) bool {
-	pf := f.Simplify()
-	a = a.Simplify()
-	return pf.Rat.Num().Cmp(a.Rat.Num()) == 0 && pf.Denom().Cmp(a.Denom()) == 0
+	return f.Rat.Num().Cmp(a.Rat.Num()) == 0 && f.Denom().Cmp(a.Denom()) == 0
 }
 
 func (f fraction) Approx(precision int) string {
@@ -79,7 +68,8 @@ func (f fraction) Approx(precision int) string {
 
 // Simplify the fraction
 func (f fraction) Simplify() *fraction {
-	divisor := gcd(f.Num(), f.Denom())
+	divisor := big.NewInt(0)
+	divisor.GCD(oneBigInt, oneBigInt, f.Num(), f.Denom())
 	if divisor.Cmp(nullBigInt) == 0 {
 		return &f
 	}

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -132,8 +132,8 @@ func TestFraction_Div(t *testing.T) {
 	}
 
 	t.Log("testing division by null fraction")
-	a = oneFraction
-	b = nullFraction
+	a = oneFraction()
+	b = nullFraction()
 	_, err = a.Div(b)
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)
@@ -153,7 +153,7 @@ func TestFraction_Inv(t *testing.T) {
 	}
 
 	t.Log("testing invert a null fraction")
-	a = nullFraction
+	a = nullFraction()
 	_, err = a.Inv()
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -54,19 +54,19 @@ func TestFractionComparison(t *testing.T) {
 	b := newFraction(7, 4)
 	t.Log("smaller or equal")
 	if !a.SmallerOrEqualThan(b) {
-		t.Errorf("a should be smaller than b")
+		t.Errorf("%s should be smaller or equal than %s", b, a)
 	}
 	t.Log("smaller")
 	if !a.SmallerThan(b) {
-		t.Errorf("a should be smaller than b")
+		t.Errorf("%s should be smaller than %s", b, a)
 	}
 	t.Log("greater or equal")
 	if a.GreaterOrEqualThan(b) {
-		t.Errorf("a should be smaller than b")
+		t.Errorf("%s should be greater or equal than %s", a, b)
 	}
 	t.Log("greater")
 	if b.GreaterThan(b) {
-		t.Errorf("a should be smaller than b")
+		t.Errorf("%s should be greater than %s", a, b)
 	}
 }
 

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestFraction_Is(t *testing.T) {
+	t.Log("testing simple is")
 	f := newFraction(3, 4)
 	if !f.Is(f) {
 		t.Errorf("%s is not %s", f, f)
@@ -18,25 +19,16 @@ func TestFraction_Is(t *testing.T) {
 	if f.Is(b) {
 		t.Errorf("%s is %s", f, b)
 	}
-}
-
-func TestFraction_Simplify(t *testing.T) {
-	t.Log("testing positive denominator")
-	f := newFraction(6, 8).Simplify()
-	expected := newFraction(3, 4)
-	if !f.Is(expected) {
-		t.Errorf("got %s; want %s", f, expected)
-	}
 
 	t.Log("testing negative denominator")
-	f = newFraction(6, -5).Simplify()
-	expected = newFraction(-6, 5)
+	f = newFraction(6, -5)
+	expected := newFraction(-6, 5)
 	if !f.Is(expected) {
 		t.Errorf("got %s; want %s", f, expected)
 	}
 
 	t.Log("testing double negative fraction")
-	f = newFraction(-6, -5).Simplify()
+	f = newFraction(-6, -5)
 	expected = newFraction(6, 5)
 	if !f.Is(expected) {
 		t.Errorf("got %s; want %s", f, expected)
@@ -90,7 +82,7 @@ func TestFraction_Add(t *testing.T) {
 	b := newFraction(8, 3)
 	expected := newFraction(7, 2)
 	res := a.Add(b)
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
@@ -100,7 +92,7 @@ func TestFraction_Sub(t *testing.T) {
 	b := newFraction(8, 3)
 	expected := newFraction(-11, 6)
 	res := a.Sub(b)
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
@@ -119,7 +111,7 @@ func TestFraction_Neg(t *testing.T) {
 	f := newFraction(5, 6)
 	expected := newFraction(-5, 6)
 	res := f.Neg()
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
@@ -154,7 +146,7 @@ func TestFraction_Inv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -172,7 +172,6 @@ func TestFraction_Approx(t *testing.T) {
 
 	t.Log("testing higher precision than exact value")
 	res = f.Approx(10)
-	expected = "3.1415000000"
 	if res != expected {
 		t.Errorf("got %s; want %s", res, expected)
 	}

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -42,6 +42,9 @@ func TestFractionComparison(t *testing.T) {
 	if !f.SmallerOrEqualThan(f) {
 		t.Errorf("fractions should be equal")
 	}
+	if !newFraction(5, 3).Is(f) {
+		t.Fatalf("fractions 5/3 and %s should be equal", f)
+	}
 	t.Log("testing smaller")
 	if f.SmallerThan(f) {
 		t.Errorf("fractions should be equal")
@@ -56,24 +59,23 @@ func TestFractionComparison(t *testing.T) {
 	}
 
 	t.Log("testing unequal fractions")
-	// a < b
-	a := f
+	// f < b
 	b := newFraction(7, 4)
 	t.Log("testing smaller or equal")
-	if !a.SmallerOrEqualThan(b) {
-		t.Errorf("%s should be smaller or equal than %s", b, a)
+	if !f.SmallerOrEqualThan(b) {
+		t.Errorf("%s should be smaller or equal than %s", b, f)
 	}
 	t.Log("testing smaller")
-	if !a.SmallerThan(b) {
-		t.Errorf("%s should be smaller than %s", b, a)
+	if !f.SmallerThan(b) {
+		t.Errorf("%s should be smaller than %s", b, f)
 	}
 	t.Log("testing greater or equal")
-	if a.GreaterOrEqualThan(b) {
-		t.Errorf("%s should be greater or equal than %s", a, b)
+	if f.GreaterOrEqualThan(b) {
+		t.Errorf("%s should be greater or equal than %s", f, b)
 	}
 	t.Log("testing greater")
 	if b.GreaterThan(b) {
-		t.Errorf("%s should be greater than %s", a, b)
+		t.Errorf("%s should be greater than %s", f, b)
 	}
 }
 

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -7,145 +7,144 @@ import (
 
 func TestFraction_Simplify(t *testing.T) {
 	t.Log("testing positive denominator")
-	f := fraction{Numerator: 6, Denominator: 8}.Simplify()
-	expected := fraction{Numerator: 3, Denominator: 4}
-	if *f != expected {
+	f := newFraction(6, 8).Simplify()
+	expected := newFraction(3, 4)
+	if !f.Is(expected) {
 		t.Errorf("got %s; want %s", f.String(), expected.String())
 	}
 
 	t.Log("testing negative denominator")
-	f = fraction{Numerator: 6, Denominator: -5}.Simplify()
-	expected = fraction{Numerator: -6, Denominator: 5}
-	if *f != expected {
+	f = newFraction(6, -5).Simplify()
+	expected = newFraction(-6, 5)
+	if !f.Is(expected) {
 		t.Errorf("got %s; want %s", f.String(), expected.String())
 	}
 
 	t.Log("testing double negative fraction")
-	f = &fraction{Numerator: -6, Denominator: -5}
-	f = f.Simplify()
-	expected = fraction{Numerator: 6, Denominator: 5}
-	if *f != expected {
+	f = newFraction(-6, -5).Simplify()
+	expected = newFraction(6, 5)
+	if !f.Is(expected) {
 		t.Errorf("got %s; want %s", f.String(), expected.String())
 	}
 }
 
 func TestFractionComparison(t *testing.T) {
 	t.Log("testing equal fraction")
-	f := fraction{Numerator: 5, Denominator: 3}
+	f := newFraction(5, 3)
 	t.Log("smaller or equal")
-	if !f.SmallerOrEqualThan(&f) {
+	if !f.SmallerOrEqualThan(f) {
 		t.Errorf("fractions should be equal")
 	}
 	t.Log("smaller")
-	if f.SmallerThan(&f) {
+	if f.SmallerThan(f) {
 		t.Errorf("fractions should be equal")
 	}
 	t.Log("greater or equal")
-	if !f.GreaterOrEqualThan(&f) {
+	if !f.GreaterOrEqualThan(f) {
 		t.Errorf("fractions should be equal")
 	}
 	t.Log("greater")
-	if f.GreaterThan(&f) {
+	if f.GreaterThan(f) {
 		t.Errorf("fractions should be equal")
 	}
 
 	t.Log("testing unequal fractions")
 	// a < b
 	a := f
-	b := fraction{Numerator: 7, Denominator: 4}
+	b := newFraction(7, 4)
 	t.Log("smaller or equal")
-	if !a.SmallerOrEqualThan(&b) {
+	if !a.SmallerOrEqualThan(b) {
 		t.Errorf("a should be smaller than b")
 	}
 	t.Log("smaller")
-	if !a.SmallerThan(&b) {
+	if !a.SmallerThan(b) {
 		t.Errorf("a should be smaller than b")
 	}
 	t.Log("greater or equal")
-	if a.GreaterOrEqualThan(&b) {
+	if a.GreaterOrEqualThan(b) {
 		t.Errorf("a should be smaller than b")
 	}
 	t.Log("greater")
-	if b.GreaterThan(&b) {
+	if b.GreaterThan(b) {
 		t.Errorf("a should be smaller than b")
 	}
 }
 
 func TestFraction_Add(t *testing.T) {
-	a := fraction{Numerator: 5, Denominator: 6}
-	b := fraction{Numerator: 8, Denominator: 3}
-	expected := fraction{Numerator: 7, Denominator: 2}
-	res := *a.Add(&b)
-	if res != expected {
+	a := newFraction(5, 6)
+	b := newFraction(8, 3)
+	expected := newFraction(7, 2)
+	res := a.Add(b)
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
 
 func TestFraction_Sub(t *testing.T) {
-	a := fraction{Numerator: 5, Denominator: 6}
-	b := fraction{Numerator: 8, Denominator: 3}
-	expected := fraction{Numerator: -11, Denominator: 6}
-	res := *a.Sub(&b)
-	if res != expected {
+	a := newFraction(5, 6)
+	b := newFraction(8, 3)
+	expected := newFraction(-11, 6)
+	res := a.Sub(b)
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
 
 func TestFraction_Mul(t *testing.T) {
-	a := fraction{Numerator: 5, Denominator: 6}
-	b := fraction{Numerator: 8, Denominator: 3}
-	expected := fraction{Numerator: 20, Denominator: 9}
-	res := *a.Mul(&b)
-	if res != expected {
+	a := newFraction(5, 6)
+	b := newFraction(8, 3)
+	expected := newFraction(20, 9)
+	res := a.Mul(b)
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
 
 func TestFraction_Neg(t *testing.T) {
-	f := fraction{Numerator: 5, Denominator: 6}
-	expected := fraction{Numerator: -5, Denominator: 6}
-	res := *f.Neg()
-	if res != expected {
+	f := newFraction(5, 6)
+	expected := newFraction(-5, 6)
+	res := f.Neg()
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
 
 func TestFraction_Div(t *testing.T) {
 	t.Log("testing division")
-	a := fraction{Numerator: 5, Denominator: 6}
-	b := fraction{Numerator: 8, Denominator: 3}
-	expected := fraction{Numerator: 5, Denominator: 16}
-	res, err := a.Div(&b)
+	a := newFraction(5, 6)
+	b := newFraction(8, 3)
+	expected := newFraction(5, 16)
+	res, err := a.Div(b)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *res != expected {
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 
 	t.Log("testing division by null fraction")
-	a = *OneFraction
-	b = *NullFraction
-	_, err = a.Div(&b)
+	a = oneFraction
+	b = nullFraction
+	_, err = a.Div(b)
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)
 	}
 }
 
 func TestFraction_Inv(t *testing.T) {
-	t.Log("testing division")
-	a := fraction{Numerator: 5, Denominator: 6}
-	expected := fraction{Numerator: 6, Denominator: 5}
+	t.Log("testing invert")
+	a := newFraction(5, 6)
+	expected := newFraction(6, 5)
 	res, err := a.Inv()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *res != expected {
+	if res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 
-	t.Log("testing division by null fraction")
-	a = *NullFraction
+	t.Log("testing invert a null fraction")
+	a = nullFraction
 	_, err = a.Inv()
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)
@@ -154,7 +153,7 @@ func TestFraction_Inv(t *testing.T) {
 
 func TestFraction_Approx(t *testing.T) {
 	expected := "3.1415"
-	f := fraction{Numerator: 6283, Denominator: 2000}
+	f := newFraction(6283, 2000)
 
 	t.Log("testing exact precision of value")
 	res := f.Approx(4)
@@ -176,7 +175,7 @@ func TestFraction_Approx(t *testing.T) {
 	}
 
 	t.Log("testing integer fraction")
-	f = *intToFraction(357)
+	f = intToFraction(357)
 	res = f.Approx(10)
 	expected = "357"
 	if res != expected {

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+func TestFraction_Is(t *testing.T) {
+	f := newFraction(3, 4)
+	if !f.Is(f) {
+		t.Errorf("%s is not %s", f, f)
+	}
+	a := newFraction(6, 8)
+	if !f.Is(a) {
+		t.Errorf("%s is not %s", f, a)
+	}
+	b := newFraction(9, 8)
+	if f.Is(b) {
+		t.Errorf("%s is %s", f, b)
+	}
+}
+
 func TestFraction_Simplify(t *testing.T) {
 	t.Log("testing positive denominator")
 	f := newFraction(6, 8).Simplify()

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -132,8 +132,8 @@ func TestFraction_Div(t *testing.T) {
 	}
 
 	t.Log("testing division by null fraction")
-	a = oneFraction()
-	b = nullFraction()
+	a = oneFraction
+	b = nullFraction
 	_, err = a.Div(b)
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)
@@ -153,7 +153,7 @@ func TestFraction_Inv(t *testing.T) {
 	}
 
 	t.Log("testing invert a null fraction")
-	a = nullFraction()
+	a = nullFraction
 	_, err = a.Inv()
 	if !errors.Is(err, ErrIllegalOperation) {
 		t.Errorf("expected illegal operation error, not %s", err)

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -38,19 +38,19 @@ func TestFraction_Is(t *testing.T) {
 func TestFractionComparison(t *testing.T) {
 	t.Log("testing equal fraction")
 	f := newFraction(5, 3)
-	t.Log("smaller or equal")
+	t.Log("testing smaller or equal")
 	if !f.SmallerOrEqualThan(f) {
 		t.Errorf("fractions should be equal")
 	}
-	t.Log("smaller")
+	t.Log("testing smaller")
 	if f.SmallerThan(f) {
 		t.Errorf("fractions should be equal")
 	}
-	t.Log("greater or equal")
+	t.Log("testing greater or equal")
 	if !f.GreaterOrEqualThan(f) {
 		t.Errorf("fractions should be equal")
 	}
-	t.Log("greater")
+	t.Log("testing greater")
 	if f.GreaterThan(f) {
 		t.Errorf("fractions should be equal")
 	}
@@ -59,19 +59,19 @@ func TestFractionComparison(t *testing.T) {
 	// a < b
 	a := f
 	b := newFraction(7, 4)
-	t.Log("smaller or equal")
+	t.Log("testing smaller or equal")
 	if !a.SmallerOrEqualThan(b) {
 		t.Errorf("%s should be smaller or equal than %s", b, a)
 	}
-	t.Log("smaller")
+	t.Log("testing smaller")
 	if !a.SmallerThan(b) {
 		t.Errorf("%s should be smaller than %s", b, a)
 	}
-	t.Log("greater or equal")
+	t.Log("testing greater or equal")
 	if a.GreaterOrEqualThan(b) {
 		t.Errorf("%s should be greater or equal than %s", a, b)
 	}
-	t.Log("greater")
+	t.Log("testing greater")
 	if b.GreaterThan(b) {
 		t.Errorf("%s should be greater than %s", a, b)
 	}

--- a/fraction_test.go
+++ b/fraction_test.go
@@ -10,21 +10,21 @@ func TestFraction_Simplify(t *testing.T) {
 	f := newFraction(6, 8).Simplify()
 	expected := newFraction(3, 4)
 	if !f.Is(expected) {
-		t.Errorf("got %s; want %s", f.String(), expected.String())
+		t.Errorf("got %s; want %s", f, expected)
 	}
 
 	t.Log("testing negative denominator")
 	f = newFraction(6, -5).Simplify()
 	expected = newFraction(-6, 5)
 	if !f.Is(expected) {
-		t.Errorf("got %s; want %s", f.String(), expected.String())
+		t.Errorf("got %s; want %s", f, expected)
 	}
 
 	t.Log("testing double negative fraction")
 	f = newFraction(-6, -5).Simplify()
 	expected = newFraction(6, 5)
 	if !f.Is(expected) {
-		t.Errorf("got %s; want %s", f.String(), expected.String())
+		t.Errorf("got %s; want %s", f, expected)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestFraction_Mul(t *testing.T) {
 	b := newFraction(8, 3)
 	expected := newFraction(20, 9)
 	res := a.Mul(b)
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 }
@@ -118,7 +118,7 @@ func TestFraction_Div(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Is(expected) {
+	if !res.Is(expected) {
 		t.Errorf("got %s; want %s", res.String(), expected.String())
 	}
 
@@ -163,6 +163,7 @@ func TestFraction_Approx(t *testing.T) {
 
 	t.Log("testing higher precision than exact value")
 	res = f.Approx(10)
+	expected = "3.1415000000"
 	if res != expected {
 		t.Errorf("got %s; want %s", res, expected)
 	}

--- a/memory.go
+++ b/memory.go
@@ -61,10 +61,15 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	pi, _ = floatToFraction(math.Pi)
+	negPiOverTwo, err := pi.Div(intToFraction(-2))
+	if err != nil {
+		panic(err)
+	}
 	tanDef := &periodicInterval{
 		Interval: &realInterval{
 			LowerBound: &intervalBound{
-				Value:        piOverTwo.Neg(),
+				Value:        negPiOverTwo,
 				IncludeValue: false,
 				Infinite:     false,
 			},

--- a/memory.go
+++ b/memory.go
@@ -81,7 +81,7 @@ func init() {
 	addFunc("tan", createMathFunction(tanDef, math.Tan))
 	addFunc("ln", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction,
+			Value:        nullFraction(),
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -93,7 +93,7 @@ func init() {
 	}, math.Log))
 	addFunc("log2", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction,
+			Value:        nullFraction(),
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -106,7 +106,7 @@ func init() {
 
 	log10 := createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction,
+			Value:        nullFraction(),
 			IncludeValue: false,
 			Infinite:     false,
 		},

--- a/memory.go
+++ b/memory.go
@@ -34,7 +34,7 @@ func init() {
 	createMathFunction := func(def space, mathFunc func(float64) float64) *mathFunction {
 		var rel relation
 		rel = func(f *fraction) *fraction {
-			x := f.Float()
+			x, _ := f.Float()
 			result, err := floatToFraction(mathFunc(x))
 			if err != nil {
 				panic(err)
@@ -81,7 +81,7 @@ func init() {
 	addFunc("tan", createMathFunction(tanDef, math.Tan))
 	addFunc("ln", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        NullFraction,
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -93,7 +93,7 @@ func init() {
 	}, math.Log))
 	addFunc("log2", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        NullFraction,
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -106,7 +106,7 @@ func init() {
 
 	log10 := createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        NullFraction,
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},

--- a/memory.go
+++ b/memory.go
@@ -24,7 +24,7 @@ func init() {
 		}
 		predefinedVariables[n] = f
 	}
-	addVar("pi", math.Pi)
+	predefinedVariables["pi"] = pi
 	addVar("e", math.E)
 	addVar("phi", math.Phi)
 
@@ -53,10 +53,6 @@ func init() {
 	addFunc("sin", createMathFunction(&realSet{}, math.Sin))
 	addFunc("cos", createMathFunction(&realSet{}, math.Cos))
 
-	pi, err := floatToFraction(math.Pi)
-	if err != nil {
-		panic(err)
-	}
 	piOverTwo, err := pi.Div(intToFraction(2))
 	if err != nil {
 		panic(err)

--- a/memory.go
+++ b/memory.go
@@ -61,15 +61,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	pi, _ = floatToFraction(math.Pi)
-	negPiOverTwo, err := pi.Div(intToFraction(-2))
-	if err != nil {
-		panic(err)
-	}
 	tanDef := &periodicInterval{
 		Interval: &realInterval{
 			LowerBound: &intervalBound{
-				Value:        negPiOverTwo,
+				Value:        piOverTwo.Neg(),
 				IncludeValue: false,
 				Infinite:     false,
 			},
@@ -86,7 +81,7 @@ func init() {
 	addFunc("tan", createMathFunction(tanDef, math.Tan))
 	addFunc("ln", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction(),
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -98,7 +93,7 @@ func init() {
 	}, math.Log))
 	addFunc("log2", createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction(),
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
@@ -111,7 +106,7 @@ func init() {
 
 	log10 := createMathFunction(&realInterval{
 		LowerBound: &intervalBound{
-			Value:        nullFraction(),
+			Value:        nullFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},

--- a/memory_test.go
+++ b/memory_test.go
@@ -2,13 +2,13 @@ package gomath
 
 import "testing"
 
-var opt = &Options{
+var testOpt = &Options{
 	Decimal:   true,
 	Precision: 6,
 }
 
 func TestMathFunction_Exp(t *testing.T) {
-	res, err := Parse("exp(0)", opt)
+	res, err := Parse("exp(0)", testOpt)
 	expected := "1"
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func TestMathFunction_Exp(t *testing.T) {
 }
 
 func TestMathFunction_Cos(t *testing.T) {
-	res, err := Parse("cos(0)", opt)
+	res, err := Parse("cos(0)", testOpt)
 	expected := "1"
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func TestMathFunction_Cos(t *testing.T) {
 }
 
 func TestMathFunction_Sin(t *testing.T) {
-	res, err := Parse("sin(0)", opt)
+	res, err := Parse("sin(0)", testOpt)
 	expected := "0"
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestMathFunction_Sin(t *testing.T) {
 }
 
 func TestMathFunction_Tan(t *testing.T) {
-	res, err := Parse("tan(0)", opt)
+	res, err := Parse("tan(0)", testOpt)
 	expected := "0"
 	if err != nil {
 		t.Fatal(err)

--- a/memory_test.go
+++ b/memory_test.go
@@ -14,7 +14,7 @@ func TestMathFunction_Exp(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res != expected {
-		t.Fatalf("got %v; want %v", res, expected)
+		t.Errorf("got %v; want %v", res, expected)
 	}
 }
 
@@ -25,7 +25,7 @@ func TestMathFunction_Cos(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res != expected {
-		t.Fatalf("got %v; want %v", res, expected)
+		t.Errorf("got %v; want %v", res, expected)
 	}
 }
 
@@ -36,7 +36,7 @@ func TestMathFunction_Sin(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res != expected {
-		t.Fatalf("got %v; want %v", res, expected)
+		t.Errorf("got %v; want %v", res, expected)
 	}
 }
 
@@ -47,6 +47,6 @@ func TestMathFunction_Tan(t *testing.T) {
 		t.Fatal(err)
 	}
 	if res != expected {
-		t.Fatalf("got %v; want %v", res, expected)
+		t.Errorf("got %v; want %v", res, expected)
 	}
 }

--- a/space.go
+++ b/space.go
@@ -128,7 +128,7 @@ func (set *periodicInterval) String() string {
 	return set.Interval.String() + " mod " + set.Period.String()
 }
 
-func (f fraction) smallerThanBound(b *intervalBound) bool {
+func (f *fraction) smallerThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return b.Positive
 	}
@@ -138,7 +138,7 @@ func (f fraction) smallerThanBound(b *intervalBound) bool {
 	return f.SmallerThan(b.Value)
 }
 
-func (f fraction) greaterThanBound(b *intervalBound) bool {
+func (f *fraction) greaterThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return !b.Positive
 	}
@@ -148,14 +148,14 @@ func (f fraction) greaterThanBound(b *intervalBound) bool {
 	return f.GreaterThan(b.Value)
 }
 
-func (f fraction) strictlySmallerThanBound(b *intervalBound) bool {
+func (f *fraction) strictlySmallerThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return b.Infinite
 	}
 	return f.SmallerThan(b.Value)
 }
 
-func (f fraction) strictlyGreaterThanBound(b *intervalBound) bool {
+func (f *fraction) strictlyGreaterThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return !b.Positive
 	}

--- a/space.go
+++ b/space.go
@@ -128,7 +128,7 @@ func (set *periodicInterval) String() string {
 	return set.Interval.String() + " mod " + set.Period.String()
 }
 
-func (f *fraction) smallerThanBound(b *intervalBound) bool {
+func (f fraction) smallerThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return b.Positive
 	}
@@ -138,7 +138,7 @@ func (f *fraction) smallerThanBound(b *intervalBound) bool {
 	return f.SmallerThan(b.Value)
 }
 
-func (f *fraction) greaterThanBound(b *intervalBound) bool {
+func (f fraction) greaterThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return !b.Positive
 	}
@@ -148,14 +148,14 @@ func (f *fraction) greaterThanBound(b *intervalBound) bool {
 	return f.GreaterThan(b.Value)
 }
 
-func (f *fraction) strictlySmallerThanBound(b *intervalBound) bool {
+func (f fraction) strictlySmallerThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return b.Infinite
 	}
 	return f.SmallerThan(b.Value)
 }
 
-func (f *fraction) strictlyGreaterThanBound(b *intervalBound) bool {
+func (f fraction) strictlyGreaterThanBound(b *intervalBound) bool {
 	if b.Infinite {
 		return !b.Positive
 	}

--- a/space_test.go
+++ b/space_test.go
@@ -6,50 +6,50 @@ func TestRealInterval_Contains(t *testing.T) {
 	t.Log("testing inclusive bounds")
 	set := realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction.Mul(intToFraction(-1)),
+			Value:        oneFraction().Mul(intToFraction(-1)),
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        oneFraction,
+			Value:        oneFraction(),
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
 
-	if !set.Contains(nullFraction) {
+	if !set.Contains(nullFraction()) {
 		t.Fatalf("0 should be in [-1, 1]")
 	}
-	if !set.Contains(oneFraction) {
+	if !set.Contains(oneFraction()) {
 		t.Fatalf("1 should be in [-1, 1]")
 	}
 
 	t.Log("testing exclusive bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction.Mul(intToFraction(-1)),
+			Value:        oneFraction().Mul(intToFraction(-1)),
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        oneFraction,
+			Value:        oneFraction(),
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
-	if !set.Contains(nullFraction) {
-		t.Fatalf("0 should be in [-1, 1]")
+	if !set.Contains(nullFraction()) {
+		t.Fatalf("0 should be in ]-1, 1[")
 	}
-	if set.Contains(oneFraction) {
+	if set.Contains(oneFraction()) {
 		t.Fatalf("1 should not be in ]-1, 1[")
 	}
 
 	t.Log("testing infinite bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction,
+			Value:        oneFraction(),
 			Infinite:     false,
 			IncludeValue: true,
 		},
@@ -59,13 +59,13 @@ func TestRealInterval_Contains(t *testing.T) {
 		},
 		CustomName: "",
 	}
-	if set.Contains(nullFraction) {
+	if set.Contains(nullFraction()) {
 		t.Fatalf("0 should not be in [1, +inf[")
 	}
-	if !set.Contains(oneFraction) {
+	if !set.Contains(oneFraction()) {
 		t.Fatalf("1 should be in [1, +inf[")
 	}
-	if !set.Contains(oneFraction.Mul(intToFraction(2))) {
+	if !set.Contains(intToFraction(2)) {
 		t.Fatalf("2 should be in [1, +inf[")
 	}
 }

--- a/space_test.go
+++ b/space_test.go
@@ -6,50 +6,50 @@ func TestRealInterval_Contains(t *testing.T) {
 	t.Log("testing inclusive bounds")
 	set := realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction().Mul(intToFraction(-1)),
+			Value:        oneFraction.Neg(),
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        oneFraction(),
+			Value:        oneFraction,
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
 
-	if !set.Contains(nullFraction()) {
+	if !set.Contains(nullFraction) {
 		t.Errorf("0 should be in [-1, 1]")
 	}
-	if !set.Contains(oneFraction()) {
+	if !set.Contains(oneFraction) {
 		t.Errorf("1 should be in [-1, 1]")
 	}
 
 	t.Log("testing exclusive bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction().Mul(intToFraction(-1)),
+			Value:        oneFraction.Mul(intToFraction(-1)),
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        oneFraction(),
+			Value:        oneFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
-	if !set.Contains(nullFraction()) {
+	if !set.Contains(nullFraction) {
 		t.Errorf("0 should be in ]-1, 1[")
 	}
-	if set.Contains(oneFraction()) {
+	if set.Contains(oneFraction) {
 		t.Errorf("1 should not be in ]-1, 1[")
 	}
 
 	t.Log("testing infinite bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        oneFraction(),
+			Value:        oneFraction,
 			Infinite:     false,
 			IncludeValue: true,
 		},
@@ -59,10 +59,10 @@ func TestRealInterval_Contains(t *testing.T) {
 		},
 		CustomName: "",
 	}
-	if set.Contains(nullFraction()) {
+	if set.Contains(nullFraction) {
 		t.Errorf("0 should not be in [1, +inf[")
 	}
-	if !set.Contains(oneFraction()) {
+	if !set.Contains(oneFraction) {
 		t.Errorf("1 should be in [1, +inf[")
 	}
 	if !set.Contains(intToFraction(2)) {

--- a/space_test.go
+++ b/space_test.go
@@ -19,10 +19,10 @@ func TestRealInterval_Contains(t *testing.T) {
 	}
 
 	if !set.Contains(nullFraction()) {
-		t.Fatalf("0 should be in [-1, 1]")
+		t.Errorf("0 should be in [-1, 1]")
 	}
 	if !set.Contains(oneFraction()) {
-		t.Fatalf("1 should be in [-1, 1]")
+		t.Errorf("1 should be in [-1, 1]")
 	}
 
 	t.Log("testing exclusive bounds")
@@ -40,10 +40,10 @@ func TestRealInterval_Contains(t *testing.T) {
 		CustomName: "",
 	}
 	if !set.Contains(nullFraction()) {
-		t.Fatalf("0 should be in ]-1, 1[")
+		t.Errorf("0 should be in ]-1, 1[")
 	}
 	if set.Contains(oneFraction()) {
-		t.Fatalf("1 should not be in ]-1, 1[")
+		t.Errorf("1 should not be in ]-1, 1[")
 	}
 
 	t.Log("testing infinite bounds")
@@ -60,12 +60,12 @@ func TestRealInterval_Contains(t *testing.T) {
 		CustomName: "",
 	}
 	if set.Contains(nullFraction()) {
-		t.Fatalf("0 should not be in [1, +inf[")
+		t.Errorf("0 should not be in [1, +inf[")
 	}
 	if !set.Contains(oneFraction()) {
-		t.Fatalf("1 should be in [1, +inf[")
+		t.Errorf("1 should be in [1, +inf[")
 	}
 	if !set.Contains(intToFraction(2)) {
-		t.Fatalf("2 should be in [1, +inf[")
+		t.Errorf("2 should be in [1, +inf[")
 	}
 }

--- a/space_test.go
+++ b/space_test.go
@@ -6,50 +6,50 @@ func TestRealInterval_Contains(t *testing.T) {
 	t.Log("testing inclusive bounds")
 	set := realInterval{
 		LowerBound: &intervalBound{
-			Value:        OneFraction.Mul(intToFraction(-1)),
+			Value:        oneFraction.Mul(intToFraction(-1)),
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        OneFraction,
+			Value:        oneFraction,
 			IncludeValue: true,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
 
-	if !set.Contains(NullFraction) {
+	if !set.Contains(nullFraction) {
 		t.Fatalf("0 should be in [-1, 1]")
 	}
-	if !set.Contains(OneFraction) {
+	if !set.Contains(oneFraction) {
 		t.Fatalf("1 should be in [-1, 1]")
 	}
 
 	t.Log("testing exclusive bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        OneFraction.Mul(intToFraction(-1)),
+			Value:        oneFraction.Mul(intToFraction(-1)),
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		UpperBound: &intervalBound{
-			Value:        OneFraction,
+			Value:        oneFraction,
 			IncludeValue: false,
 			Infinite:     false,
 		},
 		CustomName: "",
 	}
-	if !set.Contains(NullFraction) {
+	if !set.Contains(nullFraction) {
 		t.Fatalf("0 should be in [-1, 1]")
 	}
-	if set.Contains(OneFraction) {
+	if set.Contains(oneFraction) {
 		t.Fatalf("1 should not be in ]-1, 1[")
 	}
 
 	t.Log("testing infinite bounds")
 	set = realInterval{
 		LowerBound: &intervalBound{
-			Value:        OneFraction,
+			Value:        oneFraction,
 			Infinite:     false,
 			IncludeValue: true,
 		},
@@ -59,13 +59,13 @@ func TestRealInterval_Contains(t *testing.T) {
 		},
 		CustomName: "",
 	}
-	if set.Contains(NullFraction) {
+	if set.Contains(nullFraction) {
 		t.Fatalf("0 should not be in [1, +inf[")
 	}
-	if !set.Contains(OneFraction) {
+	if !set.Contains(oneFraction) {
 		t.Fatalf("1 should be in [1, +inf[")
 	}
-	if !set.Contains(OneFraction.Mul(intToFraction(2))) {
+	if !set.Contains(oneFraction.Mul(intToFraction(2))) {
 		t.Fatalf("2 should be in [1, +inf[")
 	}
 }


### PR DESCRIPTION
**Breaking change**
Fractions are mutable due to the nature of `math/big.Rat`. It's impossible to make them immutable.